### PR TITLE
Use local variables and for safeInstall and safeRemove pass on all arguments

### DIFF
--- a/bl-include.cfg
+++ b/bl-include.cfg
@@ -314,16 +314,11 @@ safeUpgrade() {
 
 # Usage safeInstall [--apt-get-option] package [package...]
 safeInstall() {
-    local arg=
-    [[ $1 = -* ]] && {
-        arg=$1
-        shift
-    }
     local ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
     local ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
     local ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
     local apt_error
-    if apt_error=$(LC_MESSAGES=C sudo apt-get install $arg "${@}" 2>&1 >/dev/tty) && ! grep -iqEv "(${ignore_string1:-$^}|${ignore_string2:-$^}|${ignore_string3:-$^}|^$)" <<<"$apt_error"
+    if apt_error=$(LC_MESSAGES=C sudo apt-get install "${@}" 2>&1 >/dev/tty) && ! grep -iqEv "(${ignore_string1:-$^}|${ignore_string2:-$^}|${ignore_string3:-$^}|^$)" <<<"$apt_error"
     then
         say 'Installation finished sucessfully.'
         return 0
@@ -335,16 +330,11 @@ safeInstall() {
 
 # Usage safeRemove [--apt-get-option] package [package...]
 safeRemove() {
-    local arg=
-    [[ $1 = -* ]] && {
-        arg=$1
-        shift
-    }
     local ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
     local ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
     local ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
     local apt_error
-    if apt_error=$(LC_MESSAGES=C sudo apt-get remove $arg "${@}" 2>&1 >/dev/tty) && ! grep -iqEv "(${ignore_string1}|${ignore_string2}|${ignore_string3}|^$)" <<<"$apt_error"
+    if apt_error=$(LC_MESSAGES=C sudo apt-get remove "${@}" 2>&1 >/dev/tty) && ! grep -iqEv "(${ignore_string1}|${ignore_string2}|${ignore_string3}|^$)" <<<"$apt_error"
     then
         say "Successfully removed ${*}"
         return 0

--- a/bl-include.cfg
+++ b/bl-include.cfg
@@ -140,6 +140,7 @@ errorExit() {
     [[ $2 ]] && {
         while true
         do
+            local REPLY
             read -rn1 -p '  Press "d" for details (q to quit) '
             [[ ${REPLY^} = Q ]] && exit 1
             [[ ${REPLY^} = D ]] && {

--- a/bl-include.cfg
+++ b/bl-include.cfg
@@ -218,7 +218,7 @@ prompt() {
 # Use: promptInstall [--apt-get-option] --setup functionname name desc...
 # to have functionname run first
 promptInstall() {
-    unset arg
+    local arg=
     if [[ $1 = -* && $1 != --setup ]]; then
         arg=$1
         shift
@@ -276,7 +276,7 @@ Hit any key to exit..."
 # apt-get update, exit if error message.
 # safeUpdate --ignore 'string' to ignore certain error message
 safeUpdate() {
-    unset ignore_string
+    local ignore_string=
     [[ $1 = '--ignore' ]] && {
         ignore_string="$2"
     }
@@ -294,13 +294,13 @@ safeUpdate() {
 # apt-get upgrade, exit if error message.
 # safeUpgrade --dist-upgrade for dist-upgrade
 safeUpgrade() {
-    cmd='upgrade'
+    local cmd='upgrade'
     [[ $1 = '--dist-upgrade' ]] && {
         cmd='dist-upgrade'
     }
-    ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
-    ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
-    ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
+    local ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
+    local ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
+    local ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
     local apt_error
     if apt_error=$(LC_MESSAGES=C sudo apt-get $cmd 2>&1 >/dev/tty) && ! grep -iqEv "(${ignore_string1:-$^}|${ignore_string2:-$^}|${ignore_string3:-$^}|^$)" <<<"$apt_error"
     then
@@ -319,9 +319,9 @@ safeInstall() {
         arg=$1
         shift
     }
-    ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
-    ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
-    ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
+    local ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
+    local ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
+    local ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
     local apt_error
     if apt_error=$(LC_MESSAGES=C sudo apt-get install $arg "${@}" 2>&1 >/dev/tty) && ! grep -iqEv "(${ignore_string1:-$^}|${ignore_string2:-$^}|${ignore_string3:-$^}|^$)" <<<"$apt_error"
     then
@@ -335,14 +335,14 @@ safeInstall() {
 
 # Usage safeRemove [--apt-get-option] package [package...]
 safeRemove() {
-    unset arg
+    local arg=
     [[ $1 = -* ]] && {
         arg=$1
         shift
     }
-    ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
-    ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
-    ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
+    local ignore_string1='Extracting templates from packages: 100%' # apt sends this to stderr!
+    local ignore_string2='Retrieving bug reports... Done' # apt-listbugs sends this to stderr!
+    local ignore_string3='Parsing Found/Fixed information... Done' # apt-listbugs sends this to stderr!
     local apt_error
     if apt_error=$(LC_MESSAGES=C sudo apt-get remove $arg "${@}" 2>&1 >/dev/tty) && ! grep -iqEv "(${ignore_string1}|${ignore_string2}|${ignore_string3}|^$)" <<<"$apt_error"
     then

--- a/bl-include.cfg
+++ b/bl-include.cfg
@@ -314,7 +314,7 @@ safeUpgrade() {
 
 # Usage safeInstall [--apt-get-option] package [package...]
 safeInstall() {
-    unset arg
+    local arg=
     [[ $1 = -* ]] && {
         arg=$1
         shift


### PR DESCRIPTION
Stop leaking function local variables into the callers variable namespace.
